### PR TITLE
PasteAiLines: fix script_namespace capitalization

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -809,15 +809,15 @@
       "description": "Convenience macro for pasting full lines exported by AI2ASS.",
       "channels": {
         "master": {
-          "version": "0.2.0",
+          "version": "0.2.1",
           "default": false,
-          "released": "2019-02-17",
+          "released": "2022-06-30",
           "files": [
             { "name": ".lua", "delete": true },
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "CE50E1E290EB75D7B25419D4333A758405641C7E"
+              "sha1": "F8A382D26729AB6402BEA09C76707E239C6A50A6"
             }
           ],
           "requiredModules": [
@@ -855,15 +855,15 @@
           "fileBaseUrl": "@{fileBaseUrl}/@{namespace}-v@{version}/@{namespace}"
         },
         "release": {
-          "version": "0.2.0",
+          "version": "0.2.1",
           "default": true,
-          "released": "2019-02-17",
+          "released": "2022-06-30",
           "files": [
             { "name": ".lua", "delete": true },
             {
               "name": ".moon",
               "url": "@{fileBaseUrl}@{fileName}",
-              "sha1": "CE50E1E290EB75D7B25419D4333A758405641C7E"
+              "sha1": "F8A382D26729AB6402BEA09C76707E239C6A50A6"
             }
           ],
           "requiredModules": [
@@ -913,6 +913,9 @@
         ],
         "0.2.0": [
           "The script was ported to MoonScript and dependencies have been updated to their latest versions."
+        ],
+        "0.2.1": [
+          "Fix script_namespace capitalization"
         ]
       }
     },

--- a/l0.PasteAiLines.moon
+++ b/l0.PasteAiLines.moon
@@ -1,8 +1,8 @@
 export script_name = "Paste AI Lines"
 export script_description = "Convenience macro for pasting full lines exported by AI2ASS."
-export script_version = "0.2.0"
+export script_version = "0.2.1"
 export script_author = "line0"
-export script_namespace = "l0.PasteAILines"
+export script_namespace = "l0.PasteAiLines"
 
 DependencyControl = require "l0.DependencyControl"
 depCtrl = DependencyControl {


### PR DESCRIPTION
Fixed `script_namespace` capitalization in PasteAiLines, which caused the macro to show up twice in DependencyControl interfaces after installing.

After merging a tag `l0.PasteAiLines-v0.2.1` also needs to be added.